### PR TITLE
Updating BASEURL for University of South Wales

### DIFF
--- a/data/libraries
+++ b/data/libraries
@@ -479,7 +479,7 @@ NAME University of South Wales
 LOCATION catalogue includes former U-Glamorgan campuses; might not yet include Newport campus
 COUNTRY UK
 CATTYPE prismhosted
-BASEURL http://prism.talis.com/glam-ac
+BASEURL http://capitadiscovery.co.uk/glam-ac
 
 ID OCLC-UKUAL
 NAME University of the Arts London


### PR DESCRIPTION
The domain name prism.talis.com is being decommissioned at the end of 2013 with capitadiscovery.co.uk taking its place.
